### PR TITLE
Mapping 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,42 @@ To execute the unit and integration tests for the application:
     ```
     *(Note: `clauses` are currently used for fee calculation if applicable but not directly stored as a list within the `Transfer` entity itself in the initial version. The DTO `ContractClauseDto` is used for request payload).*
 
+### Get Transfer Details
+-   **Endpoint**: `GET /api/v1/transfers/{transferId}`
+-   **Description**: Retrieves the details of a specific transfer.
+-   **Path Variable**:
+    -   `transferId` (UUID): The unique identifier of the transfer.
+
+### Submit Transfer for Review
+-   **Endpoint**: `PATCH /api/v1/transfers/{transferId}/submit`
+-   **Description**: Moves a transfer from `DRAFT` to `SUBMITTED` status.
+-   **Path Variable**:
+    -   `transferId` (UUID): The unique identifier of the transfer.
+
+### Move Transfer to Negotiation
+-   **Endpoint**: `PATCH /api/v1/transfers/{transferId}/negotiate`
+-   **Description**: Moves a transfer from `SUBMITTED` to `NEGOTIATION` status.
+-   **Path Variable**:
+    -   `transferId` (UUID): The unique identifier of the transfer.
+
+### Approve Transfer
+-   **Endpoint**: `PATCH /api/v1/transfers/{transferId}/approve`
+-   **Description**: Moves a transfer from `NEGOTIATION` to `APPROVED` status.
+-   **Path Variable**:
+    -   `transferId` (UUID): The unique identifier of the transfer.
+
+### Complete Transfer
+-   **Endpoint**: `PATCH /api/v1/transfers/{transferId}/complete`
+-   **Description**: Moves a transfer from `APPROVED` to `COMPLETED` status. This also updates the player's current club and adjusts club budgets based on the transfer fee.
+-   **Path Variable**:
+    -   `transferId` (UUID): The unique identifier of the transfer.
+
+### Cancel Transfer
+-   **Endpoint**: `PATCH /api/v1/transfers/{transferId}/cancel`
+-   **Description**: Moves a transfer to `CANCELED` status from an active state (e.g., `DRAFT`, `SUBMITTED`, `NEGOTIATION`, `APPROVED`).
+-   **Path Variable**:
+    -   `transferId` (UUID): The unique identifier of the transfer.
+
 ## Project Structure
 The project follows a standard layered architecture commonly used in Spring Boot applications:
 -   `com.transfersystem.controller`: Contains REST API controllers that handle incoming HTTP requests and delegate to services.

--- a/src/main/java/com/transfersystem/controller/TransferController.java
+++ b/src/main/java/com/transfersystem/controller/TransferController.java
@@ -14,6 +14,10 @@ import com.transfersystem.service.TransferFeeCalculator;
 import com.transfersystem.service.TransferWorkflowEngine;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/transfers")
@@ -63,9 +68,8 @@ public class TransferController {
         // Validate ToClub
         Club toClub = clubRepository.findById(request.getToClubId())
                 .orElseThrow(() -> new ResourceNotFoundException("ToClub not found with ID: " + request.getToClubId()));
-
         // Check if player is already in an active transfer
-        if (transferRepository.existsByPlayerIdAndStatusIn(player.getId(), ACTIVE_TRANSFER_STATUSES)) {
+        if (transferRepository.existsByPlayer_IdAndStatusIn(player.getId(), ACTIVE_TRANSFER_STATUSES)) {
             throw new IllegalStateException("Player with ID " + player.getId() + " is already in an active transfer. Cannot initiate a new one.");
         }
 
@@ -76,14 +80,119 @@ public class TransferController {
         }
 
         Transfer newTransfer = new Transfer();
-        newTransfer.setPlayerId(player.getId());
-        newTransfer.setFromClubId(fromClub.getId());
-        newTransfer.setToClubId(toClub.getId());
+        newTransfer.setPlayer(player);
+        newTransfer.setFromClub(fromClub);
+        newTransfer.setToClub(toClub);
         newTransfer.setStatus(TransferStatus.DRAFT);
         // Note: Clauses from request.getClauses() are used for fee calculation
         // but not directly stored on the Transfer entity in this version.
 
         Transfer savedTransfer = transferRepository.save(newTransfer);
         return new ResponseEntity<>(savedTransfer, HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/{transferId}/submit")
+    public ResponseEntity<Transfer> submitTransfer(@PathVariable UUID transferId) {
+        Transfer transfer = transferRepository.findById(transferId)
+                .orElseThrow(() -> new ResourceNotFoundException("Transfer not found with ID: " + transferId));
+
+        transferWorkflowEngine.submitTransfer(transfer);
+        // No need to save again, as submitTransfer is expected to persist the change.
+        // However, if submitTransfer doesn't persist, an explicit save would be needed:
+        // Transfer updatedTransfer = transferRepository.save(transfer);
+
+        return ResponseEntity.ok(transfer);
+    }
+
+    @PatchMapping("/{transferId}/negotiate")
+    public ResponseEntity<Transfer> negotiateTransfer(@PathVariable UUID transferId) {
+        Transfer transfer = transferRepository.findById(transferId)
+                .orElseThrow(() -> new ResourceNotFoundException("Transfer not found with ID: " + transferId));
+
+        transferWorkflowEngine.moveToNegotiation(transfer);
+        // No need to save again, as moveToNegotiation is expected to persist the change.
+
+        return ResponseEntity.ok(transfer);
+    }
+
+    @PatchMapping("/{transferId}/approve")
+    public ResponseEntity<Transfer> approveTransfer(@PathVariable UUID transferId) {
+        Transfer transfer = transferRepository.findById(transferId)
+                .orElseThrow(() -> new ResourceNotFoundException("Transfer not found with ID: " + transferId));
+
+        transferWorkflowEngine.approveTransfer(transfer);
+        // No need to save again, as approveTransfer is expected to persist the change.
+
+        return ResponseEntity.ok(transfer);
+    }
+
+    @PatchMapping("/{transferId}/complete")
+    @Transactional
+    public ResponseEntity<Transfer> completeTransfer(@PathVariable UUID transferId) {
+        Transfer transfer = transferRepository.findById(transferId)
+                .orElseThrow(() -> new ResourceNotFoundException("Transfer not found with ID: " + transferId));
+
+        // Call workflow engine to update status to COMPLETED (and persist it)
+        transferWorkflowEngine.completeTransfer(transfer);
+
+        // Retrieve entities from the transfer object, assuming they are loaded or accessible
+        // Note: If Player/Club objects within transfer are not fully loaded due to LAZY fetching
+        // and the session is closed (e.g. if this method wasn't @Transactional or transfer was detached),
+        // direct access like transfer.getPlayer().getName() could cause LazyInitializationException.
+        // However, since we are within a @Transactional method and transfer is managed,
+        // these should be accessible, or Hibernate will fetch them.
+        Player player = transfer.getPlayer();
+        Club toClub = transfer.getToClub();
+        Club fromClub = transfer.getFromClub();
+
+        // Validate that related entities are not null, as they are essential for completion
+        if (player == null) {
+            throw new ResourceNotFoundException("Player associated with transfer ID " + transferId + " not found or is null.");
+        }
+        if (toClub == null) {
+            throw new ResourceNotFoundException("ToClub associated with transfer ID " + transferId + " not found or is null.");
+        }
+        if (fromClub == null) {
+            throw new ResourceNotFoundException("FromClub associated with transfer ID " + transferId + " not found or is null.");
+        }
+
+        // Update player's current club
+        player.setCurrentClub(toClub);
+
+        // Calculate transfer fee (using empty list for clauses as they are not stored on Transfer)
+        BigDecimal transferFee = transferFeeCalculator.calculate(player, toClub, List.of());
+
+        // Update budgets
+        if (toClub.getBudget() != null) {
+            toClub.setBudget(toClub.getBudget().subtract(transferFee));
+        }
+        if (fromClub.getBudget() != null) {
+            fromClub.setBudget(fromClub.getBudget().add(transferFee));
+        }
+
+        // Save updated entities
+        playerRepository.save(player);
+        clubRepository.save(toClub);
+        clubRepository.save(fromClub);
+
+        return ResponseEntity.ok(transfer); // Return the transfer object, now with COMPLETED status
+    }
+
+    @PatchMapping("/{transferId}/cancel")
+    public ResponseEntity<Transfer> cancelTransfer(@PathVariable UUID transferId) {
+        Transfer transfer = transferRepository.findById(transferId)
+                .orElseThrow(() -> new ResourceNotFoundException("Transfer not found with ID: " + transferId));
+
+        transferWorkflowEngine.cancelTransfer(transfer);
+        // No need to save again, as cancelTransfer is expected to persist the change.
+
+        return ResponseEntity.ok(transfer);
+    }
+
+    @GetMapping("/{transferId}")
+    public ResponseEntity<Transfer> getTransferById(@PathVariable UUID transferId) {
+        Transfer transfer = transferRepository.findById(transferId)
+                .orElseThrow(() -> new ResourceNotFoundException("Transfer not found with ID: " + transferId));
+        return ResponseEntity.ok(transfer);
     }
 }

--- a/src/main/java/com/transfersystem/model/Player.java
+++ b/src/main/java/com/transfersystem/model/Player.java
@@ -1,9 +1,13 @@
 package com.transfersystem.model;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
@@ -19,7 +23,9 @@ public class Player {
 
     private BigDecimal currentMarketValue;
 
-    private Long currentClubId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_club_id")
+    private Club currentClub;
 
     // Getters and setters
     public Long getId() {
@@ -46,11 +52,11 @@ public class Player {
         this.currentMarketValue = currentMarketValue;
     }
 
-    public Long getCurrentClubId() {
-        return currentClubId;
+    public Club getCurrentClub() {
+        return currentClub;
     }
 
-    public void setCurrentClubId(Long currentClubId) {
-        this.currentClubId = currentClubId;
+    public void setCurrentClub(Club currentClub) {
+        this.currentClub = currentClub;
     }
 }

--- a/src/main/java/com/transfersystem/model/Transfer.java
+++ b/src/main/java/com/transfersystem/model/Transfer.java
@@ -1,10 +1,14 @@
 package com.transfersystem.model;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.annotations.GenericGenerator;
 
@@ -19,13 +23,19 @@ public class Transfer {
     private UUID id;
 
     @NotNull
-    private Long playerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "player_id")
+    private Player player;
 
     @NotNull
-    private Long fromClubId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_club_id")
+    private Club fromClub;
 
     @NotNull
-    private Long toClubId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_club_id")
+    private Club toClub;
 
     @NotNull
     @Enumerated(EnumType.STRING)
@@ -40,28 +50,28 @@ public class Transfer {
         this.id = id;
     }
 
-    public Long getPlayerId() {
-        return playerId;
+    public Player getPlayer() {
+        return player;
     }
 
-    public void setPlayerId(Long playerId) {
-        this.playerId = playerId;
+    public void setPlayer(Player player) {
+        this.player = player;
     }
 
-    public Long getFromClubId() {
-        return fromClubId;
+    public Club getFromClub() {
+        return fromClub;
     }
 
-    public void setFromClubId(Long fromClubId) {
-        this.fromClubId = fromClubId;
+    public void setFromClub(Club fromClub) {
+        this.fromClub = fromClub;
     }
 
-    public Long getToClubId() {
-        return toClubId;
+    public Club getToClub() {
+        return toClub;
     }
 
-    public void setToClubId(Long toClubId) {
-        this.toClubId = toClubId;
+    public void setToClub(Club toClub) {
+        this.toClub = toClub;
     }
 
     public TransferStatus getStatus() {

--- a/src/main/java/com/transfersystem/repository/TransferRepository.java
+++ b/src/main/java/com/transfersystem/repository/TransferRepository.java
@@ -10,5 +10,5 @@ import java.util.UUID;
 
 @Repository
 public interface TransferRepository extends JpaRepository<Transfer, UUID> {
-    boolean existsByPlayerIdAndStatusIn(Long playerId, List<TransferStatus> statuses);
+    boolean existsByPlayer_IdAndStatusIn(Long playerId, List<TransferStatus> statuses);
 }

--- a/src/test/java/com/transfersystem/controller/TransferControllerTest.java
+++ b/src/test/java/com/transfersystem/controller/TransferControllerTest.java
@@ -1,8 +1,7 @@
 package com.transfersystem.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.transfersystem.dto.ContractClauseDto;
-import com.transfersystem.dto.InitiateTransferRequest;
+import com.transfersystem.exception.ResourceNotFoundException;
 import com.transfersystem.model.Club;
 import com.transfersystem.model.Player;
 import com.transfersystem.model.Transfer;
@@ -10,25 +9,25 @@ import com.transfersystem.model.TransferStatus;
 import com.transfersystem.repository.ClubRepository;
 import com.transfersystem.repository.PlayerRepository;
 import com.transfersystem.repository.TransferRepository;
+import com.transfersystem.service.TransferFeeCalculator;
 import com.transfersystem.service.TransferWorkflowEngine;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(TransferController.class)
 public class TransferControllerTest {
@@ -49,95 +48,312 @@ public class TransferControllerTest {
     private ClubRepository clubRepository;
 
     @MockBean
-    private TransferWorkflowEngine transferWorkflowEngine; // Though not directly used in initiateTransfer
+    private TransferWorkflowEngine transferWorkflowEngine;
 
+    @MockBean
+    private TransferFeeCalculator transferFeeCalculator;
+
+    private Transfer sampleTransfer;
+    private Player samplePlayer;
+    private Club fromClub;
+    private Club toClub;
+    private UUID transferId;
+    private UUID playerId;
+    private UUID fromClubId;
+    private UUID toClubId;
+
+    @BeforeEach
+    void setUp() {
+        transferId = UUID.randomUUID();
+        playerId = UUID.randomUUID();
+        fromClubId = UUID.randomUUID();
+        toClubId = UUID.randomUUID();
+
+        samplePlayer = new Player();
+        samplePlayer.setId(playerId);
+        samplePlayer.setName("Test Player");
+        samplePlayer.setCurrentClubId(fromClubId);
+        samplePlayer.setMarketValue(new BigDecimal("500000")); // Added for fee calculation
+
+        fromClub = new Club();
+        fromClub.setId(fromClubId);
+        fromClub.setName("From Club");
+        fromClub.setBudget(new BigDecimal("1000000"));
+
+        toClub = new Club();
+        toClub.setId(toClubId);
+        toClub.setName("To Club");
+        toClub.setBudget(new BigDecimal("2000000"));
+
+        sampleTransfer = new Transfer();
+        sampleTransfer.setId(transferId);
+        sampleTransfer.setPlayerId(playerId);
+        sampleTransfer.setFromClubId(fromClubId);
+        sampleTransfer.setToClubId(toClubId);
+        sampleTransfer.setStatus(TransferStatus.DRAFT); // Default status
+    }
+
+    // --- Test GetTransferDetails ---
     @Test
-    void initiateTransfer_validRequest_shouldReturnCreated() throws Exception {
-        Long playerId = 1L;
-        Long fromClubId = 10L;
-        Long toClubId = 20L;
+    void getTransferById_whenTransferExists_shouldReturnTransferAndOk() throws Exception {
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
 
-        InitiateTransferRequest request = new InitiateTransferRequest();
-        request.setPlayerId(playerId);
-        request.setFromClubId(fromClubId);
-        request.setToClubId(toClubId);
-        List<ContractClauseDto> clauses = new ArrayList<>();
-        clauses.add(new ContractClauseDto("SELL_ON", BigDecimal.TEN, null));
-        request.setClauses(clauses);
-
-        when(playerRepository.existsById(playerId)).thenReturn(true);
-        when(clubRepository.existsById(fromClubId)).thenReturn(true);
-        when(clubRepository.existsById(toClubId)).thenReturn(true);
-
-        Transfer savedTransfer = new Transfer();
-        savedTransfer.setId(UUID.randomUUID());
-        savedTransfer.setPlayerId(playerId);
-        savedTransfer.setFromClubId(fromClubId);
-        savedTransfer.setToClubId(toClubId);
-        savedTransfer.setStatus(TransferStatus.DRAFT);
-
-        when(transferRepository.save(any(Transfer.class))).thenReturn(savedTransfer);
-
-        mockMvc.perform(post("/api/v1/transfers")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(savedTransfer.getId().toString()))
-                .andExpect(jsonPath("$.playerId").value(playerId))
-                .andExpect(jsonPath("$.fromClubId").value(fromClubId))
-                .andExpect(jsonPath("$.toClubId").value(toClubId))
-                .andExpect(jsonPath("$.status").value(TransferStatus.DRAFT.toString()));
+        mockMvc.perform(get("/api/v1/transfers/{transferId}", transferId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(transferId.toString()))
+                .andExpect(jsonPath("$.playerId").value(playerId.toString()))
+                .andExpect(jsonPath("$.status").value(sampleTransfer.getStatus().toString()));
     }
 
     @Test
-    void initiateTransfer_playerNotFound_shouldReturnBadRequest() throws Exception {
-        InitiateTransferRequest request = new InitiateTransferRequest();
-        request.setPlayerId(1L);
-        request.setFromClubId(10L);
-        request.setToClubId(20L);
+    void getTransferById_whenTransferNotFound_shouldReturnNotFound() throws Exception {
+        when(transferRepository.findById(transferId)).thenReturn(Optional.empty());
 
-        when(playerRepository.existsById(1L)).thenReturn(false); // Player does not exist
+        mockMvc.perform(get("/api/v1/transfers/{transferId}", transferId))
+                .andExpect(status().isNotFound());
+    }
 
-        mockMvc.perform(post("/api/v1/transfers")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest()) // Assuming IllegalArgumentException maps to 400
-                .andExpect(MockMvcResultMatchers.content().string("Player not found with ID: 1"));
+    // --- Test SubmitTransfer ---
+    @Test
+    void submitTransfer_whenTransferExistsAndDraft_shouldReturnSubmittedAndOk() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.DRAFT);
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        // Mock workflow engine to change status
+        doAnswer(invocation -> {
+            Transfer t = invocation.getArgument(0);
+            t.setStatus(TransferStatus.SUBMITTED);
+            return null; // void method
+        }).when(transferWorkflowEngine).submitTransfer(any(Transfer.class));
 
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/submit", transferId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(transferId.toString()))
+                .andExpect(jsonPath("$.status").value(TransferStatus.SUBMITTED.toString()));
+
+        verify(transferWorkflowEngine).submitTransfer(sampleTransfer);
     }
 
     @Test
-    void initiateTransfer_fromClubNotFound_shouldReturnBadRequest() throws Exception {
-        InitiateTransferRequest request = new InitiateTransferRequest();
-        request.setPlayerId(1L);
-        request.setFromClubId(10L);
-        request.setToClubId(20L);
+    void submitTransfer_whenTransferNotFound_shouldReturnNotFound() throws Exception {
+        when(transferRepository.findById(transferId)).thenReturn(Optional.empty());
 
-        when(playerRepository.existsById(1L)).thenReturn(true);
-        when(clubRepository.existsById(10L)).thenReturn(false); // FromClub does not exist
-
-        mockMvc.perform(post("/api/v1/transfers")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(MockMvcResultMatchers.content().string("Originating club not found with ID: 10"));
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/submit", transferId))
+                .andExpect(status().isNotFound());
     }
 
     @Test
-    void initiateTransfer_toClubNotFound_shouldReturnBadRequest() throws Exception {
-        InitiateTransferRequest request = new InitiateTransferRequest();
-        request.setPlayerId(1L);
-        request.setFromClubId(10L);
-        request.setToClubId(20L);
+    void submitTransfer_whenWorkflowEngineThrowsIllegalState_shouldReturnConflict() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.COMPLETED); // An invalid state to submit
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doThrow(new IllegalStateException("Cannot submit a completed transfer"))
+                .when(transferWorkflowEngine).submitTransfer(any(Transfer.class));
 
-        when(playerRepository.existsById(1L)).thenReturn(true);
-        when(clubRepository.existsById(10L)).thenReturn(true);
-        when(clubRepository.existsById(20L)).thenReturn(false); // ToClub does not exist
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/submit", transferId))
+                .andExpect(status().isConflict()); // Or 400, depending on GlobalExceptionHandler
+    }
 
-        mockMvc.perform(post("/api/v1/transfers")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(MockMvcResultMatchers.content().string("Destination club not found with ID: 20"));
+
+    // --- Test MoveToNegotiation ---
+    @Test
+    void moveToNegotiation_whenTransferSubmitted_shouldReturnNegotiationAndOk() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.SUBMITTED);
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doAnswer(invocation -> {
+            Transfer t = invocation.getArgument(0);
+            t.setStatus(TransferStatus.NEGOTIATION);
+            return null;
+        }).when(transferWorkflowEngine).moveToNegotiation(any(Transfer.class));
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/negotiate", transferId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(TransferStatus.NEGOTIATION.toString()));
+        verify(transferWorkflowEngine).moveToNegotiation(sampleTransfer);
+    }
+
+    @Test
+    void moveToNegotiation_whenTransferNotFound_shouldReturnNotFound() throws Exception {
+        when(transferRepository.findById(transferId)).thenReturn(Optional.empty());
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/negotiate", transferId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void moveToNegotiation_whenWorkflowEngineThrowsIllegalState_shouldReturnConflict() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.DRAFT); // Invalid state for negotiation
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doThrow(new IllegalStateException("Cannot move DRAFT to negotiation"))
+                .when(transferWorkflowEngine).moveToNegotiation(any(Transfer.class));
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/negotiate", transferId))
+                .andExpect(status().isConflict());
+    }
+
+    // --- Test ApproveTransfer ---
+    @Test
+    void approveTransfer_whenTransferInNegotiation_shouldReturnApprovedAndOk() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.NEGOTIATION);
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doAnswer(invocation -> {
+            Transfer t = invocation.getArgument(0);
+            t.setStatus(TransferStatus.APPROVED);
+            return null;
+        }).when(transferWorkflowEngine).approveTransfer(any(Transfer.class));
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/approve", transferId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(TransferStatus.APPROVED.toString()));
+        verify(transferWorkflowEngine).approveTransfer(sampleTransfer);
+    }
+
+    @Test
+    void approveTransfer_whenTransferNotFound_shouldReturnNotFound() throws Exception {
+        when(transferRepository.findById(transferId)).thenReturn(Optional.empty());
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/approve", transferId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void approveTransfer_whenWorkflowEngineThrowsIllegalState_shouldReturnConflict() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.SUBMITTED); // Invalid state for approval
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doThrow(new IllegalStateException("Cannot approve SUBMITTED transfer directly"))
+                .when(transferWorkflowEngine).approveTransfer(any(Transfer.class));
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/approve", transferId))
+                .andExpect(status().isConflict());
+    }
+
+    // --- Test CancelTransfer ---
+    @Test
+    void cancelTransfer_whenTransferIsCancellable_shouldReturnCanceledAndOk() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.SUBMITTED); // A cancellable state
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doAnswer(invocation -> {
+            Transfer t = invocation.getArgument(0);
+            t.setStatus(TransferStatus.CANCELED);
+            return null;
+        }).when(transferWorkflowEngine).cancelTransfer(any(Transfer.class));
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/cancel", transferId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(TransferStatus.CANCELED.toString()));
+        verify(transferWorkflowEngine).cancelTransfer(sampleTransfer);
+    }
+
+    @Test
+    void cancelTransfer_whenTransferNotFound_shouldReturnNotFound() throws Exception {
+        when(transferRepository.findById(transferId)).thenReturn(Optional.empty());
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/cancel", transferId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void cancelTransfer_whenWorkflowEngineThrowsIllegalState_shouldReturnConflict() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.COMPLETED); // Non-cancellable state
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doThrow(new IllegalStateException("Cannot cancel a COMPLETED transfer"))
+                .when(transferWorkflowEngine).cancelTransfer(any(Transfer.class));
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/cancel", transferId))
+                .andExpect(status().isConflict());
+    }
+
+    // --- Test CompleteTransfer ---
+    @Test
+    void completeTransfer_whenTransferApproved_shouldCompleteAndUpdateEntitiesAndOk() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.APPROVED);
+        BigDecimal calculatedFee = new BigDecimal("50000");
+
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doAnswer(invocation -> {
+            Transfer t = invocation.getArgument(0);
+            t.setStatus(TransferStatus.COMPLETED);
+            return null;
+        }).when(transferWorkflowEngine).completeTransfer(any(Transfer.class));
+
+        when(playerRepository.findById(playerId)).thenReturn(Optional.of(samplePlayer));
+        when(clubRepository.findById(toClubId)).thenReturn(Optional.of(toClub));
+        when(clubRepository.findById(fromClubId)).thenReturn(Optional.of(fromClub));
+        when(transferFeeCalculator.calculate(samplePlayer, toClub, List.of())).thenReturn(calculatedFee);
+
+        // Initial budgets
+        BigDecimal initialToClubBudget = toClub.getBudget();
+        BigDecimal initialFromClubBudget = fromClub.getBudget();
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/complete", transferId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(transferId.toString()))
+                .andExpect(jsonPath("$.status").value(TransferStatus.COMPLETED.toString()));
+
+        verify(transferWorkflowEngine).completeTransfer(sampleTransfer);
+        verify(playerRepository).findById(playerId);
+        verify(clubRepository).findById(toClubId);
+        verify(clubRepository).findById(fromClubId);
+        verify(transferFeeCalculator).calculate(samplePlayer, toClub, List.of());
+
+        // Verify player's club updated
+        verify(samplePlayer).setCurrentClubId(toClubId);
+        verify(playerRepository).save(samplePlayer);
+
+        // Verify club budgets updated
+        verify(toClub).setBudget(initialToClubBudget.subtract(calculatedFee));
+        verify(fromClub).setBudget(initialFromClubBudget.add(calculatedFee));
+        verify(clubRepository).save(toClub);
+        verify(clubRepository).save(fromClub);
+    }
+
+    @Test
+    void completeTransfer_whenTransferNotFound_shouldReturnNotFound() throws Exception {
+        when(transferRepository.findById(transferId)).thenReturn(Optional.empty());
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/complete", transferId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void completeTransfer_whenPlayerNotFoundDuringUpdate_shouldReturnNotFound() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.APPROVED);
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doNothing().when(transferWorkflowEngine).completeTransfer(any(Transfer.class)); // Simulate status update
+
+        when(playerRepository.findById(playerId)).thenReturn(Optional.empty()); // Player not found
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/complete", transferId))
+                .andExpect(status().isNotFound()); // Expect 404 due to ResourceNotFoundException for player
+    }
+
+    @Test
+    void completeTransfer_whenToClubNotFoundDuringUpdate_shouldReturnNotFound() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.APPROVED);
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doNothing().when(transferWorkflowEngine).completeTransfer(any(Transfer.class));
+        when(playerRepository.findById(playerId)).thenReturn(Optional.of(samplePlayer));
+        when(clubRepository.findById(toClubId)).thenReturn(Optional.empty()); // ToClub not found
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/complete", transferId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void completeTransfer_whenFromClubNotFoundDuringUpdate_shouldReturnNotFound() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.APPROVED);
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doNothing().when(transferWorkflowEngine).completeTransfer(any(Transfer.class));
+        when(playerRepository.findById(playerId)).thenReturn(Optional.of(samplePlayer));
+        when(clubRepository.findById(toClubId)).thenReturn(Optional.of(toClub));
+        when(clubRepository.findById(fromClubId)).thenReturn(Optional.empty()); // FromClub not found
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/complete", transferId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void completeTransfer_whenWorkflowEngineThrowsIllegalState_shouldReturnConflict() throws Exception {
+        sampleTransfer.setStatus(TransferStatus.DRAFT); // Invalid state for completion
+        when(transferRepository.findById(transferId)).thenReturn(Optional.of(sampleTransfer));
+        doThrow(new IllegalStateException("Cannot complete a DRAFT transfer"))
+                .when(transferWorkflowEngine).completeTransfer(any(Transfer.class));
+
+        mockMvc.perform(patch("/api/v1/transfers/{transferId}/complete", transferId))
+                .andExpect(status().isConflict());
     }
 }


### PR DESCRIPTION
feat: Implement full relational mapping for Player and Transfer entities

This commit refactors the core entities (`Player`, `Transfer`) to use proper JPA `@ManyToOne` associations instead of raw ID fields. This enhances the data model's integrity, type safety, and makes working with related entities more straightforward.

Changes include:

1.  **Player Entity**:
    *   `currentClubId` (Long) changed to `currentClub` (Club) with `@ManyToOne` mapping.

2.  **Transfer Entity**:
    *   `playerId` (Long) changed to `player` (Player) with `@ManyToOne` mapping.
    *   `fromClubId` (Long) changed to `fromClub` (Club) with `@ManyToOne` mapping.
    *   `toClubId` (Long) changed to `toClub` (Club) with `@ManyToOne` mapping.

3.  **TransferController**:
    *   Updated `initiateTransfer` to set fetched Player/Club entities directly on the new Transfer object.
    *   Updated `completeTransfer` to use getters like `transfer.getPlayer()` and `transfer.getToClub()` and to set `player.setCurrentClub(clubEntity)`.
    *   Adjusted the call to `transferRepository.existsByPlayer_IdAndStatusIn`.

4.  **TransferRepository**:
    *   Renamed method `existsByPlayerIdAndStatusIn` to `existsByPlayer_IdAndStatusIn` to align with new mapping.

5.  **DTOs and Services**:
    *   `InitiateTransferRequest` DTO confirmed to correctly use Long IDs for request payloads.
    *   `TransferWorkflowEngine` and `TransferFeeCalculator` were reviewed and required no changes due to this refactoring.

Note: Unit tests have not yet been updated to reflect these changes. This will be addressed in a subsequent commit. The current submission is based on your request to submit pending work.